### PR TITLE
fix "Continue Reading..."

### DIFF
--- a/templates/partials/item/summary.html.twig
+++ b/templates/partials/item/summary.html.twig
@@ -68,7 +68,7 @@
 {% if page.summary == page.content %}
   {{ page.summary|raw }}
 {% else %}
-  {{ page.content|safe_truncate_html(550)|raw }}
+  {{ page.summary }}  
   {% if page.header.show_clickthrough ?? true %}<p><a href="{{ page.url }}">Continue Reading...</a></p> {% endif %}
 {% endif %}
 

--- a/templates/partials/item/summary.html.twig
+++ b/templates/partials/item/summary.html.twig
@@ -65,10 +65,10 @@
 </p>
 
 {# Text #}
-{% if page.summary != page.content %}
+{% if page.summary == page.content %}
   {{ page.summary|raw }}
 {% else %}
-  {{ page.content|truncate(550)|raw }}
+  {{ page.content|safe_truncate_html(550)|raw }}
   {% if page.header.show_clickthrough ?? true %}<p><a href="{{ page.url }}">Continue Reading...</a></p> {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Hi, I found a bug in the blog display and fixed it.

Before this fix, "Continue Reading..." was displayed when the ``page.summary`` and ``page.content`` were equal.  The correct logic is the other way around, right?
Then I found a function ``safe_truncate_html`` that cuts down the number of characters without destroying the html tags, so I changed it to that. [Twig Filters & Functions | Grav Documentation](https://learn.getgrav.org/16/themes/twig-filters-functions#specialized-versions)

Thanks for a very good theme! I love the simplicity of it.