### PR TITLE
fix escaping of content in languages.yaml

### DIFF
--- a/templates/partials/item/grid.html.twig
+++ b/templates/partials/item/grid.html.twig
@@ -53,9 +53,9 @@
 <td>
   {% if show_date %}
     {% if html5 %}
-      {{ 'THEME_HYPERTEXT.DATES.PUBLISHED'|t }}: <time datetime="{{ page.date|date("c") }}">{{ page.date|date(system.pages.dateformat.short) }}</time>
+      {{ 'THEME_HYPERTEXT.DATES.PUBLISHED'|t|raw }}: <time datetime="{{ page.date|date("c") }}">{{ page.date|date(system.pages.dateformat.short) }}</time>
     {% else %}
-      {{ 'THEME_HYPERTEXT.DATES.PUBLISHED'|t }}: <span class="datetime">{{ page.date|date(system.pages.dateformat.short) }}</span>
+      {{ 'THEME_HYPERTEXT.DATES.PUBLISHED'|t|raw }}: <span class="datetime">{{ page.date|date(system.pages.dateformat.short) }}</span>
     {% endif %}
   {% endif %}
 </td>
@@ -63,7 +63,7 @@
 {# Categories #}
 <td>
 {% if page.taxonomy.category and show_cat %}
-  {{ 'THEME_HYPERTEXT.CATEGORIES.CATEGORIES'|t }}: 
+  {{ 'THEME_HYPERTEXT.CATEGORIES.CATEGORIES'|t|raw }}: 
   {% for category in page.taxonomy.category %}
     {{ structure.use_decorators ? '[' : '' }}<a href="{{ page.parent.url|rtrim('/') }}/category{{ config.system.param_sep }}{{ category }}">{{ category }}</a>{{ structure.use_decorators ? ']' : '' }}{{ not loop.last ? ',' : '' }}
   {% endfor %}

--- a/templates/partials/item/table.html.twig
+++ b/templates/partials/item/table.html.twig
@@ -9,10 +9,10 @@
 <table class="children" width="100%">
   {# Header #}
   {{ html5 ? '<thead>' : ''}}<tr>
-    {% if show_image %}<td>{{ 'THEME_HYPERTEXT.THUMBNAIL.THUMBNAIL'|t }}</td>{% endif %}
+    {% if show_image %}<td>{{ 'THEME_HYPERTEXT.THUMBNAIL.THUMBNAIL'|t|raw }}</td>{% endif %}
     <td>Title</td>
-    {% if show_date %}<td>{{ 'THEME_HYPERTEXT.DATES.PUBLISHED'|t }}</td>{% endif %}
-    {% if show_cat %}<td>{{ 'THEME_HYPERTEXT.CATEGORIES.CATEGORIES'|t }}</td>{% endif %}
+    {% if show_date %}<td>{{ 'THEME_HYPERTEXT.DATES.PUBLISHED'|t|raw }}</td>{% endif %}
+    {% if show_cat %}<td>{{ 'THEME_HYPERTEXT.CATEGORIES.CATEGORIES'|t|raw }}</td>{% endif %}
   {{ html5 ? '</thead>' : ''}}</tr>
 
   {% for child in collection if child.isPage() %}

--- a/templates/partials/page/footer.html.twig
+++ b/templates/partials/page/footer.html.twig
@@ -9,7 +9,7 @@
 {% endif %}
 
 {# Be cool; please leave the attribution in unless you really need to remove it. ;) #}
-<p>{{ 'THEME_HYPERTEXT.FOOTER.BY_LINE'|t }}</p>
+<p>{{ 'THEME_HYPERTEXT.FOOTER.BY_LINE'|t|raw }}</p>
 
 {% block bottom %}
 {% if allowJS %}

--- a/templates/partials/page/pagination.html.twig
+++ b/templates/partials/page/pagination.html.twig
@@ -9,9 +9,9 @@
 {{ html5 ? '<nav class="pagination">' : '<div class="pagination">' }}
   {% if pagination.hasPrev %}
     {% set url = (base_url ~ pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
-    <a rel="prev" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t }}</a>
+    <a rel="prev" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t|raw }}</a>
   {% else %}
-    <span>{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t }}</span>
+    <span>{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t|raw }}</span>
   {% endif %}
 
   {% for paginate in pagination %}
@@ -27,9 +27,9 @@
 
   {% if pagination.hasNext %}
     {% set url = (base_url ~ pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
-    , <a rel="next" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t }}</a>
+    , <a rel="next" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t|raw }}</a>
   {% else %}
-    , <span>{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t }}</span>
+    , <span>{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t|raw }}</span>
   {% endif %}
 {{ html5 ? '</nav>' : '</div>' }}
 
@@ -39,9 +39,9 @@
 <ul>
   {% if pagination.hasPrev %}
     {% set url = (base_url ~ pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
-    <li><a rel="prev" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t }}</a></li>
+    <li><a rel="prev" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t|raw }}</a></li>
   {% else %}
-    <li><span>{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t }}</span></li>
+    <li><span>{{ 'THEME_HYPERTEXT.PAGINATION.PREVIOUS_PAGE'|t|raw }}</span></li>
   {% endif %}
 
   {% for paginate in pagination %}
@@ -58,9 +58,9 @@
   {% endfor %}
   {% if pagination.hasNext %}
     {% set url = (base_url ~ pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
-    <li><a rel="next" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t }}</a></li>
+    <li><a rel="next" href="{{ url }}">{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t|raw }}</a></li>
   {% else %}
-    <li><span>{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t }}</span></li>
+    <li><span>{{ 'THEME_HYPERTEXT.PAGINATION.NEXT_PAGE'|t|raw }}</span></li>
   {% endif %}
 </ul>
 {{ html5 ? '</nav>' : '</div>' }}


### PR DESCRIPTION
I noticed that the HTML of the footer message was escaped. Similar to the issue #47 I have fixed the escaping of the contents in languages.yaml