### PR TITLE
Make page title suffix optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.4.0
+## 05/25/2023
+
+1. [](#new)
+    * Adds an option for whether or not to use the site title in every page `title` element.
+    * 
+
 # v2.3.0
 ## 05/25/2023
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -34,6 +34,17 @@ form:
                       type: section
                       title: Navigation Structure
                       underline: true
+                    structure.add_site_name:
+                      type: toggle
+                      label: Add site name to page titles
+                      help: When enabled, page titles will end with a pipe seperator and the name of the website. When disabled, only your page's title will be used.
+                      default: 1
+                      highlight: 1
+                      options:
+                        1: Enabled
+                        0: Disabled
+                      validate:
+                        type: bool
                     structure.inline_navbar:
                       type: toggle
                       label: Use inline menu bar

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -34,7 +34,12 @@
     <meta {% if meta.name %}name="{{ meta.name }}" {% endif %}{% if meta.http_equiv %}http-equiv="{{ meta.http_equiv }}" {% endif %}{% if meta.charset %}charset="{{ meta.charset }}" {% endif %}{% if meta.property %}property="{{ meta.property }}" {% endif %}{% if meta.content %}content="{{ meta.content }}" {% endif %}/>
   {% endfor %}
 
-  <title>{% if header.title %}{{ header.title|e('html') }} | {% endif %}{{ site.title|e('html') }}</title>
+  {% if structure.add_site_name %}
+    <title>{% if header.title %}{{ header.title|e('html') }} | {% endif %}{{ site.title|e('html') }}</title>
+  {% else %}
+    {% if header.title %}<title>{{ header.title|e('html') }}</title>{% endif %}
+  {% endif %}
+  
 
   {% if structure.use_favicon %}
   <link rel="icon" type="image/png" href="{{ url('image://favicon/favicon.png') }}" />


### PR DESCRIPTION
Adds an option for whether or not to use the site title in every page `title` element.